### PR TITLE
feat: 🎸 allow users to view logs from our namespaces in os

### DIFF
--- a/.github/workflows/go-vet-lint-deps.yaml
+++ b/.github/workflows/go-vet-lint-deps.yaml
@@ -17,12 +17,11 @@ jobs:
       # Install Go on the VM running the action.
       - uses: actions/setup-go@v4
         with:
-          go-version: ">=1.19.0"
+          go-version: "=1.21.3"
 
       - name: Perform staticcheck on codebase
-        uses: dominikh/staticcheck-action@v1.3.0
+        uses: dominikh/staticcheck-action@v1.3.1
         with:
-          version: "2022.1"
           install-go: false
 
       - name: Install gofumpt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.21-alpine AS builder
+FROM golang:1.21.3-alpine AS builder
 
 RUN addgroup -g 1000 -S appgroup && \
   adduser -u 1000 -S appuser -G appgroup
 
-RUN mkdir -p app/certs
+RUN mkdir -p /app/certs
 
 RUN apk --no-cache add ca-certificates
 

--- a/pkg/mutate/mutate_test.go
+++ b/pkg/mutate/mutate_test.go
@@ -29,10 +29,6 @@ func TestMutate(t *testing.T) {
 		getGithubTeamName func(string) string
 	}
 
-	type want struct {
-		resultJSON []byte
-	}
-
 	tests := []struct {
 		name    string
 		args    args

--- a/pkg/namespace/get-team-name.go
+++ b/pkg/namespace/get-team-name.go
@@ -35,12 +35,12 @@ func InitGetGithubTeamName(getTeamName func(string) (string, error)) func(string
 
 		githubTeamName, err = getTeamName(ns)
 		if err != nil {
-			return "webops"
+			return "all-org-members"
 		}
 
 		isSystemNs := utils.Contains(systemNamespaces, ns)
 		if isSystemNs {
-			githubTeamName = "webops"
+			return "all-org-members"
 		}
 
 		return githubTeamName

--- a/routes/mutate.go
+++ b/routes/mutate.go
@@ -36,6 +36,14 @@ func initMutatePod(r *gin.Engine) {
 			utils.SendResponse(c, errObj)
 		}
 
-		c.Writer.Write(mutated)
+		_, writeErr := c.Writer.Write(mutated)
+		if writeErr != nil {
+			errObj := utils.Response{
+				Status: http.StatusInternalServerError,
+				Data:   nil,
+			}
+
+			utils.SendResponse(c, errObj)
+		}
 	})
 }

--- a/routes/mutate.go
+++ b/routes/mutate.go
@@ -1,7 +1,7 @@
 package routes
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -12,7 +12,7 @@ import (
 
 func initMutatePod(r *gin.Engine) {
 	r.POST("/mutate/pod", func(c *gin.Context) {
-		body, err := ioutil.ReadAll(c.Request.Body)
+		body, err := io.ReadAll(c.Request.Body)
 		defer c.Request.Body.Close()
 
 		if err != nil {


### PR DESCRIPTION
- Allow users to view logs from our system namespaces, label our pods with `all-org-members`. This will then populate the `github_teams` field in opensearch
- fix ci checks
